### PR TITLE
0.3.0 release

### DIFF
--- a/grt/config/objective/lidar3d.yaml
+++ b/grt/config/objective/lidar3d.yaml
@@ -7,6 +7,7 @@ occupancy3d:
     _target_: nrdk.objectives.Occupancy3D
     range_weighted: True
     positive_weight: 16.0
+    max_points: 10000
     mode: spherical
     vis_config:
       cols: 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nrdk"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
   { name="Tianshu Huang", email="tianshu2@andrew.cmu.edu" },
 ]

--- a/src/nrdk/config/logging.py
+++ b/src/nrdk/config/logging.py
@@ -33,7 +33,12 @@ def configure_rich_logging(
     """
     root = logging.getLogger()
     root.setLevel(level)
-    root.handlers.clear()
+
+    # Remove existing stdout handler to replace it with rich; other handlers
+    # (e.g., file handlers from Hydra) are preserved.
+    for handler in root.handlers[:]:
+        if type(handler) is logging.StreamHandler:
+            root.removeHandler(handler)
 
     rich_handler = RichHandler(markup=True)
     fmt = logging.Formatter("[orange1]%(name)s:[/orange1] %(message)s")

--- a/src/nrdk/framework/__init__.py
+++ b/src/nrdk/framework/__init__.py
@@ -13,7 +13,7 @@ from nrdk._typecheck import typechecker
 
 with typechecker("nrdk.framework"):
     from .architectures import Output, TokenizerEncoderDecoder
-    from .callbacks import PerformanceMonitor
+    from .callbacks import GradientStats, PerformanceMonitor
     from .lightningmodule import NRDKLightningModule
     from .load import load_model
     from .logging import LoggerWithImages, MLFlowLogger, TensorBoardLogger
@@ -22,6 +22,6 @@ with typechecker("nrdk.framework"):
 __all__ = [
     "load_model",
     "Output", "TokenizerEncoderDecoder",
-    "PerformanceMonitor",
+    "GradientStats", "PerformanceMonitor",
     "LoggerWithImages", "MLFlowLogger", "TensorBoardLogger",
     "NRDKLightningModule", "Result"]

--- a/src/nrdk/framework/architectures.py
+++ b/src/nrdk/framework/architectures.py
@@ -49,8 +49,8 @@ class TokenizerEncoderDecoder(nn.Module):
     """
 
     def __init__(
-        self, tokenizer: nn.Module, encoder: nn.Module,
-        decoder: Mapping[str, nn.Module],
+        self, tokenizer: nn.Module, encoder: nn.Module | None = None,
+        decoder: Mapping[str, nn.Module] = {},
         key: str = "spectrum", squeeze: bool = True
     ) -> None:
         super().__init__()
@@ -83,10 +83,13 @@ class TokenizerEncoderDecoder(nn.Module):
             outputs.update(tokens.output)
             tokens = tokens.stage
 
-        encoded = self.encoder(tokens)
-        if isinstance(encoded, Output):
-            outputs.update(encoded.output)
-            encoded = encoded.stage
+        if self.encoder is not None:
+            encoded = self.encoder(tokens)
+            if isinstance(encoded, Output):
+                outputs.update(encoded.output)
+                encoded = encoded.stage
+        else:
+            encoded = tokens
 
         decoded = {k: v(encoded) for k, v in self.decoder.items()}
 

--- a/src/nrdk/framework/architectures.py
+++ b/src/nrdk/framework/architectures.py
@@ -40,8 +40,8 @@ class TokenizerEncoderDecoder(nn.Module):
         and model components are compatible (i.e., have the correct type).
 
     Args:
-        tokenizer: tokenizer module.
-        encoder: encoder module.
+        tokenizer: tokenizer module; skipped if `None`.
+        encoder: encoder module; skipped if `None`.
         decoder: decoder modules; each key corresponds to the output key.
         key: key in the input data to use as the model input.
         squeeze: eliminate non-temporal, non-batch singleton axes in the
@@ -49,11 +49,17 @@ class TokenizerEncoderDecoder(nn.Module):
     """
 
     def __init__(
-        self, tokenizer: nn.Module, encoder: nn.Module | None = None,
+        self,
+        tokenizer: nn.Module | None = None,
+        encoder: nn.Module | None = None,
         decoder: Mapping[str, nn.Module] = {},
         key: str = "spectrum", squeeze: bool = True
     ) -> None:
         super().__init__()
+
+        if len(decoder) == 0:
+            raise ValueError("At least one decoder must be provided.")
+
         self.tokenizer = tokenizer
         self.encoder = encoder
         self.decoder = nn.ModuleDict(decoder)
@@ -78,10 +84,14 @@ class TokenizerEncoderDecoder(nn.Module):
         outputs = {}
 
         x = data[self.key]
-        tokens = self.tokenizer(x)
-        if isinstance(tokens, Output):
-            outputs.update(tokens.output)
-            tokens = tokens.stage
+
+        if self.tokenizer is not None:
+            tokens = self.tokenizer(x)
+            if isinstance(tokens, Output):
+                outputs.update(tokens.output)
+                tokens = tokens.stage
+        else:
+            tokens = x
 
         if self.encoder is not None:
             encoded = self.encoder(tokens)

--- a/src/nrdk/framework/callbacks.py
+++ b/src/nrdk/framework/callbacks.py
@@ -86,10 +86,10 @@ class GradientStats(Callback):
 
     def on_after_backward(self, trainer, pl_module) -> None:
         # Note that gradients should be synchronized across shards already!
-        total_norm = torch.nn.utils.get_total_norm(
-            p.grad for p in pl_module.parameters() if p.grad is not None)
+        norm = torch.nn.utils.get_total_norm(
+            p.grad for p in pl_module.parameters() if p.grad is not None
+        ).item()
 
-        norm = torch.tensor(total_norm).item()
         self.m1 += norm
         self.m2 += norm**2
         self.min = min(self.min, norm)

--- a/src/nrdk/framework/lightningmodule.py
+++ b/src/nrdk/framework/lightningmodule.py
@@ -403,11 +403,3 @@ class NRDKLightningModule(
     def configure_optimizers(self) -> torch.optim.Optimizer:
         """Configure optimizers; passthrough to the provided `Optimizer`."""
         return self.optimizer(self.parameters())
-
-    def on_before_optimizer_step(
-        self, optimizer: torch.optim.Optimizer
-    ) -> None:
-        """Called before each optimizer step."""
-        total_norm = torch.nn.utils.get_total_norm(
-            p.grad for p in self.parameters() if p.grad is not None)
-        self.log("loss/grad_norm", total_norm)

--- a/src/nrdk/framework/lightningmodule.py
+++ b/src/nrdk/framework/lightningmodule.py
@@ -98,7 +98,7 @@ class NRDKLightningModule(
         self.log = torch.compiler.disable(self.log)  # type: ignore
         self.log_dict = torch.compiler.disable(self.log_dict)  # type: ignore
 
-    def compile(self) -> None:
+    def compile(self, dynamic: bool = True) -> None:
         """Compile model in-place.
 
         !!! bug
@@ -116,7 +116,7 @@ class NRDKLightningModule(
                 "torch.compile is currently incompatible with jaxtyping; "
                 "if you see type errors, set the environment variable "
                 "`JAXTYPING_DISABLE=1` to disable jaxtyping checks.")
-        super().compile()
+        super().compile(dynamic=dynamic)
         self._log.info("LightningModule compiled with torch.compile.")
 
     # NOTE: any @torch.compiler.disable method breaks the type checker. Any
@@ -294,8 +294,8 @@ class NRDKLightningModule(
         y_true, y_pred = self(batch)
 
         loss, metrics = self.objective(y_true, y_pred, train=True)
-        loss = torch.mean(loss)
-        metrics = {k: torch.mean(v) for k, v in metrics.items()}
+        loss = torch.nanmean(loss)
+        metrics = {k: torch.nanmean(v) for k, v in metrics.items()}
 
         self.log_dict(
             {f"{k}/train": v for k, v in metrics.items()},
@@ -329,8 +329,8 @@ class NRDKLightningModule(
         """Standard lightning validation step."""
         y_true, y_pred = self(batch)
         loss, metrics = self.objective(y_true, y_pred, train=False)
-        loss = torch.mean(loss)
-        metrics = {k: torch.mean(v) for k, v in metrics.items()}
+        loss = torch.nanmean(loss)
+        metrics = {k: torch.nanmean(v) for k, v in metrics.items()}
 
         self.log_dict(
             {f"{k}/val": v for k, v in metrics.items()}, sync_dist=True)
@@ -399,6 +399,27 @@ class NRDKLightningModule(
                 else:
                     rendered = self.objective.render(y_true, y_hat)
                     yield np_metrics, rendered
+
+    def on_before_optimizer_step(
+        self, optimizer: torch.optim.Optimizer
+    ) -> None:
+        """Skip optimizer step if any gradients are non-finite.
+
+        This is needed when using `bf16-mixed` precision, which unlike
+        `fp16-mixed` does not use a `GradScaler` and therefore does not
+        automatically skip updates on NaN/Inf gradients.
+        """
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                if p.grad is not None and not torch.isfinite(p.grad).all():
+                    self._log.warning(
+                        f"Non-finite gradient detected at step "
+                        f"{self.global_step}; skipping update.")
+                    self.log(
+                        "train/nan_grad_skip", 1.0,
+                        on_step=True, on_epoch=False)
+                    self.zero_grad()
+                    return
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         """Configure optimizers; passthrough to the provided `Optimizer`."""

--- a/src/nrdk/metrics/__init__.py
+++ b/src/nrdk/metrics/__init__.py
@@ -18,10 +18,10 @@ with typechecker("nrdk.metrics"):
         lp_power,
         mean_with_mask,
     )
-    from .pointcloud import PolarChamfer2D, PolarChamfer3D
+    from .pointcloud import PointCloudMetric, PolarChamfer2D, PolarChamfer3D
 
 __all__ = [
     "BCE", "BinaryDiceLoss", "FocalLoss",
     "DepthWithConfidence", "Lp", "VoxelDepth", "lp_power", "mean_with_mask",
-    "PolarChamfer2D", "PolarChamfer3D",
+    "PolarChamfer2D", "PolarChamfer3D", "PointCloudMetric",
 ]

--- a/src/nrdk/metrics/metrics.py
+++ b/src/nrdk/metrics/metrics.py
@@ -128,13 +128,7 @@ class VoxelDepth:
                 in each azimuth/elevation bin.
         """
         diff = lp_power(y_true - y_hat)
-        batch = y_true.shape[0]
-        if mask is None:
-            return torch.mean(diff.reshape(batch, -1), dim=1)
-        else:
-            total = torch.sum((diff * mask).reshape(batch, -1), dim=1)
-            n_valid = torch.sum(mask.reshape(batch, -1), dim=1)
-            return total / n_valid
+        return mean_with_mask(diff, mask)
 
     def __call__(
         self, y_true: Bool[Tensor, "batch *spatial"],

--- a/src/nrdk/metrics/pointcloud.py
+++ b/src/nrdk/metrics/pointcloud.py
@@ -122,7 +122,8 @@ class PointCloudMetric(ABC):
 class PolarChamfer2D(PointCloudMetric):
     """2D point cloud metrics for range-azimuth occupancy grids.
 
-    Returns the error in grid units.
+    Returns the error in grid units; see [`PointCloudMetric`][^.] for more
+    details.
 
     !!! warning "Not differentiable"
 
@@ -163,7 +164,8 @@ class PolarChamfer2D(PointCloudMetric):
 class PolarChamfer3D(PointCloudMetric):
     """3D point cloud metrics for elevation-azimuth depth maps.
 
-    Returns the error in grid units.
+    Returns the error in grid units; see [`PointCloudMetric`][^.] for more
+    details.
 
     !!! warning "Image Axis Order"
 

--- a/src/nrdk/metrics/pointcloud.py
+++ b/src/nrdk/metrics/pointcloud.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 from beartype.typing import Literal
-from jaxtyping import Bool, Float, Num, Shaped
+from jaxtyping import Float, Shaped
 from torch import Tensor
 
 
@@ -22,17 +22,28 @@ class PointCloudMetric(ABC):
     - `hausdorff`: hausdorff distance (max)
     - `modhausdorff`: modified hausdorff distance (median)
 
+    If `max_points` is set, inputs which produce more than `max_points` points
+    will be subsampled to `max_points`.
+
+    - `float` tensors (i.e., logits) are subsampled by weighted sampling
+        without replacement proportional to sigmoid(logit) values.
+    - `bool` tensors are subsampled uniformly without replacement.
+
     Args:
         mode: specified modes.
         on_empty: value to use if one of the provided maps is completely empty.
+        max_points: if set, limit each point cloud to this many points before
+            computing distances.
     """
 
     def __init__(
         self, on_empty: float = 64.0,
-        mode: Literal["chamfer", "hausdorff", "modhausdorff"] = "chamfer"
+        mode: Literal["chamfer", "hausdorff", "modhausdorff"] = "chamfer",
+        max_points: int | None = None,
     ) -> None:
         self.mode = mode
         self.on_empty = on_empty
+        self.max_points = max_points
 
     @abstractmethod
     def as_points(self, data: Shaped[Tensor, "..."]) -> Float[Tensor, "n d"]:
@@ -43,6 +54,32 @@ class PointCloudMetric(ABC):
         """
         ...
 
+    def _limit(self, data: Tensor) -> Tensor:
+        """Subsample occupied cells to at most max_points."""
+        # not set
+        if self.max_points is None:
+            return data
+
+        # below limit
+        occ_idx = (data > 0).nonzero(as_tuple=False)  # [n, ndim]
+        if len(occ_idx) <= self.max_points:
+            return data
+
+        # sampling required
+        if data.dtype == torch.bool:
+            weights = torch.ones(len(occ_idx), device=data.device)
+        else:
+            weights = torch.sigmoid(data[tuple(occ_idx.T)])
+        sampled = torch.multinomial(weights, self.max_points, replacement=False)
+        keep = occ_idx[sampled]
+        result = torch.zeros_like(data)
+        if data.dtype == torch.bool:
+            result[tuple(keep.T)] = True
+        else:
+            result[tuple(keep.T)] = data[tuple(keep.T)]
+
+        return result
+
     @staticmethod
     def distance(
         x: Float[Tensor, "n1 d"], y: Float[Tensor, "n2 d"]
@@ -52,9 +89,10 @@ class PointCloudMetric(ABC):
             x[:, None, :] - y[None, :, :]
         ), dim=-1))
 
+    @torch.compiler.disable
     def _forward(self, x, y):
-        pts_x = self.as_points(x)
-        pts_y = self.as_points(y)
+        pts_x = self.as_points(self._limit(x))
+        pts_y = self.as_points(self._limit(y))
         dist = self.distance(pts_x, pts_y)
 
         if dist.shape[0] == 0 or dist.shape[1] == 0:
@@ -74,7 +112,10 @@ class PointCloudMetric(ABC):
         self, y_hat: Shaped[Tensor, "..."], y_true: Shaped[Tensor, "..."],
     ) -> Float[Tensor, "batch"]:
         """Compute point cloud metric."""
-        _iter = (self._forward(xs, ys) for xs, ys in zip(y_hat, y_true))
+        _iter = (
+            # torch.compiler.disable is type-jank
+            self._forward(xs, ys)  # type: ignore
+            for xs, ys in zip(y_hat, y_true))
         return torch.stack(list(_iter))
 
 
@@ -90,19 +131,23 @@ class PolarChamfer2D(PointCloudMetric):
         mode: specified modes.
         az_min: minimum azimuth angle in radians.
         az_max: maximum azimuth angle in radians.
+        max_points: if set, limit each point cloud to this many points before
+            computing distances. Predictions keep the top-k cells by logit
+            value; ground truth keeps the first k occupied cells.
     """
 
     def __init__(
         self, on_empty: float = 64.0,
         mode: Literal["chamfer", "hausdorff", "modhausdorff"] = "chamfer",
-        az_min: float = -np.pi / 2, az_max: float = np.pi / 2
+        az_min: float = -np.pi / 2, az_max: float = np.pi / 2,
+        max_points: int | None = None,
     ) -> None:
-        super().__init__(on_empty=on_empty, mode=mode)
+        super().__init__(on_empty=on_empty, mode=mode, max_points=max_points)
         self.az_min = az_min
         self.az_max = az_max
 
     def as_points(
-        self, data: Bool[Tensor, "azimuth range"]
+        self, data: Shaped[Tensor, "azimuth range"]
     ) -> Float[Tensor, "n 2"]:
         """Convert (azimuth, range) occupancy grid to points."""
         Na, Nr = data.shape
@@ -110,8 +155,8 @@ class PolarChamfer2D(PointCloudMetric):
             self.az_min, self.az_max, Na, device=data.device)
 
         az, r = torch.where(data)
-        x = torch.cos(az_angles)[az] * r
-        y = torch.sin(az_angles)[az] * r
+        x = torch.cos(az_angles)[az] * (r + 1)
+        y = torch.sin(az_angles)[az] * (r + 1)
         return torch.stack([x, y], dim=-1)
 
 
@@ -134,34 +179,39 @@ class PolarChamfer3D(PointCloudMetric):
         az_max: maximum azimuth angle in radians.
         el_min: minimum elevation angle in radians.
         el_max: maximum elevation angle in radians.
+        max_points: if set, limit each point cloud to this many points before
+            computing distances. Predictions keep the top-k cells by logit
+            value; ground truth keeps the first k occupied cells.
     """
 
     def __init__(
         self, on_empty: float = 64.0,
         mode: Literal["chamfer", "hausdorff", "modhausdorff"] = "chamfer",
         az_min: float = -np.pi / 2, az_max: float = np.pi / 2,
-        el_min: float = -np.pi / 4, el_max: float = np.pi / 4
+        el_min: float = -np.pi / 4, el_max: float = np.pi / 4,
+        max_points: int | None = None,
     ) -> None:
-        super().__init__(on_empty=on_empty, mode=mode)
+        super().__init__(on_empty=on_empty, mode=mode, max_points=max_points)
         self.az_min = az_min
         self.az_max = az_max
         self.el_min = el_min
         self.el_max = el_max
 
     def as_points(
-        self, data: Num[Tensor, "elevation azimuth"]
+        self, data: Shaped[Tensor, "elevation azimuth range"]
     ) -> Float[Tensor, "n 3"]:
-        """Convert elevation-azimuth depth maps to points."""
-        Ne, Na = data.shape
+        """Convert (elevation, azimuth, range) occupancy grid to points."""
+        Ne, Na, _Nr = data.shape
         el_angles = torch.linspace(
             self.el_max, self.el_min, Ne, device=data.device)
         az_angles = torch.linspace(
             self.az_min, self.az_max, Na, device=data.device)
 
-        el, az = torch.where(data)
+        el, az, rng = torch.where(data)
+        rng = rng.float() + 1
         _el_cos = torch.cos(el_angles)[el]
-        x = _el_cos * torch.cos(az_angles)[az] * data[el, az]
-        y = _el_cos * torch.sin(az_angles)[az] * data[el, az]
-        z = torch.sin(el_angles)[el] * data[el, az]
+        x = _el_cos * torch.cos(az_angles)[az] * rng
+        y = _el_cos * torch.sin(az_angles)[az] * rng
+        z = torch.sin(el_angles)[el] * rng
 
         return torch.stack([x, y, z], dim=-1)

--- a/src/nrdk/modules/conv.py
+++ b/src/nrdk/modules/conv.py
@@ -52,7 +52,9 @@ class ConvNextLayer(nn.Module):
     def forward(self, x: Float[Tensor, "b c h w"]) -> Float[Tensor, "b c h w"]:
         """Forward pass through the ConvNext layer."""
         x1 = self.dw(x)
-        x1 = self.norm(x1.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous()
+        x1 = self.norm(
+            x1.permute(0, 2, 3, 1).contiguous()
+        ).permute(0, 3, 1, 2).contiguous()
         x1 = self.pw2(self.act(self.pw1(x1)))
         if self.gamma is not None:
             x1 = self.gamma[None, :, None, None] * x1

--- a/src/nrdk/objectives/occupancy.py
+++ b/src/nrdk/objectives/occupancy.py
@@ -102,10 +102,15 @@ class Occupancy3D(Objective[
             sparsity / class imbalance.
         max_range: value to assign to chamfer loss when there are no points;
             nominally the number of range bins.
+        mode: coordinate mode for range weighting; `spherical` or `cylindrical`.
         az_min: minimum azimuth angle.
         az_max: maximum azimuth angle.
         el_min: minimum elevation angle.
         el_max: maximum elevation angle.
+        max_points: if set, limit each chamfer point cloud to this many points.
+            Predictions are sampled without replacement weighted by
+            sigmoid(logit); ground truth is sampled uniformly. Prevents OOM on
+            dense occupancy grids.
         vis_config: visualization configuration; the `cmaps` can have `bev`
             and `depth` keys.
     """
@@ -116,6 +121,7 @@ class Occupancy3D(Objective[
         mode: Literal["spherical", "cylindrical"] = "spherical",
         az_min: float = -np.pi / 2, az_max: float = np.pi / 2,
         el_min: float = -np.pi / 4, el_max: float = np.pi / 4,
+        max_points: int | None = None,
         vis_config: VisualizationConfig | Mapping[str, Any] = {},
     ) -> None:
         self.az_min = az_min
@@ -126,11 +132,12 @@ class Occupancy3D(Objective[
         self.bce = BCE(
             positive_weight=positive_weight,
             weighting=mode if range_weighted else None)
-        self.height = VoxelDepth(axis=2, reverse=True, ord=1)
-        self.depth = VoxelDepth(axis=0, reverse=False, ord=1)
+        self.height = VoxelDepth(axis=0, reverse=True, ord=1)
+        self.depth = VoxelDepth(axis=2, reverse=False, ord=1)
         self.chamfer = PolarChamfer3D(
             mode='chamfer', az_min=az_min, az_max=az_max,
-            el_min=el_min, el_max=el_max, on_empty=max_range)
+            el_min=el_min, el_max=el_max, on_empty=max_range,
+            max_points=max_points)
 
         if not isinstance(vis_config, VisualizationConfig):
             vis_config = VisualizationConfig(**vis_config)
@@ -152,9 +159,7 @@ class Occupancy3D(Objective[
             "depth": self.depth(occ_true, occ_hat)
         }
         if not train:
-            depth_true = torch.argmax(occ_true.to(torch.uint8), dim=-1)
-            depth_hat = torch.argmax(occ_hat.to(torch.uint8), dim=-1)
-            metrics["chamfer"] = self.chamfer(depth_hat, depth_true)
+            metrics["chamfer"] = self.chamfer(_y_pred, occ_true)
 
         # Temporal reduction
         metrics = {
@@ -248,6 +253,10 @@ class Occupancy2D(Objective[
         bce_weight: BCE loss weight; Dice loss is weighted `1 - bce_weight`.
         az_min: minimum azimuth angle.
         az_max: maximum azimuth angle.
+        max_points: if set, limit each chamfer point cloud to this many points.
+            Predictions are sampled without replacement weighted by
+            sigmoid(logit); ground truth is sampled uniformly. Prevents OOM on
+            dense occupancy grids.
         vis_config: visualization configuration; `cmaps` can have a `bev` key.
     """
 
@@ -255,6 +264,7 @@ class Occupancy2D(Objective[
         self, range_weighted: bool = True, positive_weight: float = 1.0,
         bce_weight: float = 0.9,
         az_min: float = -np.pi / 2, az_max: float = np.pi / 2,
+        max_points: int | None = None,
         vis_config: VisualizationConfig | Mapping = {},
     ) -> None:
         self.az_min = az_min
@@ -267,7 +277,8 @@ class Occupancy2D(Objective[
         self.dice_loss = BinaryDiceLoss(
             weighting='cylindrical' if range_weighted else None)
         self.chamfer = PolarChamfer2D(
-            mode="chamfer", az_min=az_min, az_max=az_max)
+            mode="chamfer", az_min=az_min, az_max=az_max,
+            max_points=max_points)
 
         if not isinstance(vis_config, VisualizationConfig):
             vis_config = VisualizationConfig(**vis_config)
@@ -289,7 +300,7 @@ class Occupancy2D(Objective[
                 occ_true[:, None, :, :], sigmoid(_y_pred[:, None, :, :]))
         }
         if not train:
-            metrics["chamfer"] = self.chamfer(_y_pred > 0, occ_true)
+            metrics["chamfer"] = self.chamfer(_y_pred, occ_true)
 
         # Temporal reduction
         metrics = {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -270,22 +270,21 @@ def test_polar_chamfer_2d_empty():
 
 
 def test_polar_chamfer_3d_basic():
-    """Test PolarChamfer3D with basic depth maps."""
+    """Test PolarChamfer3D with basic occupancy grids."""
     chamfer = PolarChamfer3D()
 
-    # Create simple depth maps with positive values
-    torch.manual_seed(42)
-    y_true = torch.zeros(2, 4, 8)
-    y_hat = torch.zeros(2, 4, 8)
+    # Shape: [batch, elevation, azimuth, range]
+    y_true = torch.zeros(2, 4, 8, 16, dtype=torch.bool)
+    y_hat = torch.zeros(2, 4, 8, 16, dtype=torch.bool)
 
-    # Add some depth values
-    y_true[0, 1, 2] = 5.0
-    y_true[0, 2, 3] = 10.0
-    y_hat[0, 1, 3] = 6.0
-    y_hat[0, 2, 2] = 9.0
+    # Occupied at (el=1, az=2, rng=5) and (el=2, az=3, rng=10)
+    y_true[0, 1, 2, 5] = True
+    y_true[0, 2, 3, 10] = True
+    y_hat[0, 1, 3, 6] = True
+    y_hat[0, 2, 2, 9] = True
 
-    y_true[1, 0, 1] = 3.0
-    y_hat[1, 0, 1] = 3.0  # Perfect match
+    y_true[1, 0, 1, 3] = True
+    y_hat[1, 0, 1, 3] = True  # Perfect match
 
     loss = chamfer(y_hat, y_true)
 
@@ -295,12 +294,13 @@ def test_polar_chamfer_3d_basic():
 
 def test_polar_chamfer_3d_modes():
     """Test PolarChamfer3D with different modes."""
-    y_true = torch.zeros(1, 4, 4)
-    y_hat = torch.zeros(1, 4, 4)
+    # Shape: [batch, elevation, azimuth, range]
+    y_true = torch.zeros(1, 4, 4, 8, dtype=torch.bool)
+    y_hat = torch.zeros(1, 4, 4, 8, dtype=torch.bool)
 
-    # Add some points
-    y_true[0, 1, 1] = 5.0
-    y_hat[0, 1, 2] = 5.0
+    # Two nearby occupied cells
+    y_true[0, 1, 1, 5] = True
+    y_hat[0, 1, 2, 5] = True
 
     # Test different modes
     for mode in ["chamfer", "hausdorff", "modhausdorff"]:

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "nrdk"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "abstract-dataloader" },


### PR DESCRIPTION
## 3D Metrics fixes
- Fixed axis ordering bug in depth computation for point cloud metrics (#24)
- Replaced distance-based Chamfer with sampling-based Chamfer for more stable estimates
- Improved docs for point cloud metrics

## Training pipeline improvements
- Moved gradient norm logging to a dedicated `GradLogCallback` with richer per-layer stats (mean, std, max)
- Added `dynamic=False` to `torch.compile` calls and more robust NaN-skipping in the training loop
- Added a raw output mode to `NRDKLightningModule` for objectives that bypass the standard tokenizer/encoder/decoder pipeline
- Logging fix for non-rank-0 processes

## Architecture flexibility
- `TokenizerEncoderDecoder` now supports encoder-less (decoder-only) architectures via `encoder=None` and tokenizer-less architectures via `tokenizer=None`
- Fixed warning about doubled tensor conversion in model forward pass
- Conv `contiguous()` fix for compatibility with compiled models
