### PR TITLE
Fix point-cloud limiting for float logits

### DIFF
--- a/src/nrdk/metrics/pointcloud.py
+++ b/src/nrdk/metrics/pointcloud.py
@@ -22,62 +22,26 @@ class PointCloudMetric(ABC):
     - `hausdorff`: hausdorff distance (max)
     - `modhausdorff`: modified hausdorff distance (median)
 
-    If `max_points` is set, inputs which produce more than `max_points` points
-    will be subsampled to `max_points`.
-
-    - `float` tensors (i.e., logits) are subsampled by weighted sampling
-        without replacement proportional to sigmoid(logit) values.
-    - `bool` tensors are subsampled uniformly without replacement.
-
     Args:
         mode: specified modes.
         on_empty: value to use if one of the provided maps is completely empty.
-        max_points: if set, limit each point cloud to this many points before
-            computing distances.
     """
 
     def __init__(
         self, on_empty: float = 64.0,
         mode: Literal["chamfer", "hausdorff", "modhausdorff"] = "chamfer",
-        max_points: int | None = None,
     ) -> None:
         self.mode = mode
         self.on_empty = on_empty
-        self.max_points = max_points
 
     @abstractmethod
-    def as_points(self, data: Bool[Tensor, "..."]) -> Float[Tensor, "n d"]:
+    def as_points(self, data: Shaped[Tensor, "..."]) -> Float[Tensor, "n d"]:
         """Convert a model's native representation to cartesian points.
 
         Note that since the output number of points may vary across a batch,
         this method is not batched.
         """
         ...
-
-    def _limit(self, data: Tensor) -> Bool[Tensor, "..."]:
-        """Subsample occupied cells to at most max_points."""
-        occupied = data if data.dtype == torch.bool else data > 0
-        
-        # not set
-        if self.max_points is None:
-            return occupied
-
-        # below limit
-        occ_idx = occupied.nonzero(as_tuple=False)  # [n, ndim]
-        if len(occ_idx) <= self.max_points:
-            return occupied
-
-        # sampling required
-        if data.dtype == torch.bool:
-            weights = torch.ones(len(occ_idx), device=data.device)
-        else:
-            weights = torch.sigmoid(data[tuple(occ_idx.T)])
-        sampled = torch.multinomial(weights, self.max_points, replacement=False)
-        keep = occ_idx[sampled]
-        result = torch.zeros_like(occupied)
-        result[tuple(keep.T)] = True
-
-        return result
 
     @staticmethod
     def distance(
@@ -90,8 +54,8 @@ class PointCloudMetric(ABC):
 
     @torch.compiler.disable
     def _forward(self, x, y):
-        pts_x = self.as_points(self._limit(x))
-        pts_y = self.as_points(self._limit(y))
+        pts_x = self.as_points(x)
+        pts_y = self.as_points(y)
         dist = self.distance(pts_x, pts_y)
 
         if dist.shape[0] == 0 or dist.shape[1] == 0:
@@ -132,8 +96,8 @@ class PolarChamfer2D(PointCloudMetric):
         az_min: minimum azimuth angle in radians.
         az_max: maximum azimuth angle in radians.
         max_points: if set, limit each point cloud to this many points before
-            computing distances. Predictions keep the top-k cells by logit
-            value; ground truth keeps the first k occupied cells.
+            computing distances. Predictions are sampled without replacement
+            weighted by sigmoid(logit); ground truth is sampled uniformly.
     """
 
     def __init__(
@@ -142,14 +106,39 @@ class PolarChamfer2D(PointCloudMetric):
         az_min: float = -np.pi / 2, az_max: float = np.pi / 2,
         max_points: int | None = None,
     ) -> None:
-        super().__init__(on_empty=on_empty, mode=mode, max_points=max_points)
+        super().__init__(on_empty=on_empty, mode=mode)
         self.az_min = az_min
         self.az_max = az_max
+        self.max_points = max_points
+
+    @staticmethod
+    def _limit(data: Tensor, max_points: int | None) -> Bool[Tensor, "..."]:
+        """Subsample occupied cells to at most max_points."""
+        occupied = data if data.dtype == torch.bool else data > 0
+
+        if max_points is None:
+            return occupied
+
+        occ_idx = occupied.nonzero(as_tuple=False)  # [n, ndim]
+        if len(occ_idx) <= max_points:
+            return occupied
+
+        if data.dtype == torch.bool:
+            weights = torch.ones(len(occ_idx), device=data.device)
+        else:
+            weights = torch.sigmoid(data[tuple(occ_idx.T)])
+        sampled = torch.multinomial(weights, max_points, replacement=False)
+        keep = occ_idx[sampled]
+        result = torch.zeros_like(occupied)
+        result[tuple(keep.T)] = True
+
+        return result
 
     def as_points(
-        self, data: Bool[Tensor, "azimuth range"]
+        self, data: Shaped[Tensor, "azimuth range"]
     ) -> Float[Tensor, "n 2"]:
         """Convert (azimuth, range) occupancy grid to points."""
+        data = self._limit(data, self.max_points)
         Na, Nr = data.shape
         az_angles = torch.linspace(
             self.az_min, self.az_max, Na, device=data.device)
@@ -181,8 +170,8 @@ class PolarChamfer3D(PointCloudMetric):
         el_min: minimum elevation angle in radians.
         el_max: maximum elevation angle in radians.
         max_points: if set, limit each point cloud to this many points before
-            computing distances. Predictions keep the top-k cells by logit
-            value; ground truth keeps the first k occupied cells.
+            computing distances. Predictions are sampled without replacement
+            weighted by sigmoid(logit); ground truth is sampled uniformly.
     """
 
     def __init__(
@@ -192,16 +181,41 @@ class PolarChamfer3D(PointCloudMetric):
         el_min: float = -np.pi / 4, el_max: float = np.pi / 4,
         max_points: int | None = None,
     ) -> None:
-        super().__init__(on_empty=on_empty, mode=mode, max_points=max_points)
+        super().__init__(on_empty=on_empty, mode=mode)
         self.az_min = az_min
         self.az_max = az_max
         self.el_min = el_min
         self.el_max = el_max
+        self.max_points = max_points
+
+    @staticmethod
+    def _limit(data: Tensor, max_points: int | None) -> Bool[Tensor, "..."]:
+        """Subsample occupied cells to at most max_points."""
+        occupied = data if data.dtype == torch.bool else data > 0
+
+        if max_points is None:
+            return occupied
+
+        occ_idx = occupied.nonzero(as_tuple=False)  # [n, ndim]
+        if len(occ_idx) <= max_points:
+            return occupied
+
+        if data.dtype == torch.bool:
+            weights = torch.ones(len(occ_idx), device=data.device)
+        else:
+            weights = torch.sigmoid(data[tuple(occ_idx.T)])
+        sampled = torch.multinomial(weights, max_points, replacement=False)
+        keep = occ_idx[sampled]
+        result = torch.zeros_like(occupied)
+        result[tuple(keep.T)] = True
+
+        return result
 
     def as_points(
-        self, data: Bool[Tensor, "elevation azimuth range"]
+        self, data: Shaped[Tensor, "elevation azimuth range"]
     ) -> Float[Tensor, "n 3"]:
         """Convert (elevation, azimuth, range) occupancy grid to points."""
+        data = self._limit(data, self.max_points)
         Ne, Na, _Nr = data.shape
         el_angles = torch.linspace(
             self.el_max, self.el_min, Ne, device=data.device)

--- a/src/nrdk/metrics/pointcloud.py
+++ b/src/nrdk/metrics/pointcloud.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 from beartype.typing import Literal
-from jaxtyping import Float, Shaped
+from jaxtyping import Bool, Float, Shaped
 from torch import Tensor
 
 
@@ -46,7 +46,7 @@ class PointCloudMetric(ABC):
         self.max_points = max_points
 
     @abstractmethod
-    def as_points(self, data: Shaped[Tensor, "..."]) -> Float[Tensor, "n d"]:
+    def as_points(self, data: Bool[Tensor, "..."]) -> Float[Tensor, "n d"]:
         """Convert a model's native representation to cartesian points.
 
         Note that since the output number of points may vary across a batch,
@@ -54,16 +54,18 @@ class PointCloudMetric(ABC):
         """
         ...
 
-    def _limit(self, data: Tensor) -> Tensor:
+    def _limit(self, data: Tensor) -> Bool[Tensor, "..."]:
         """Subsample occupied cells to at most max_points."""
+        occupied = data if data.dtype == torch.bool else data > 0
+        
         # not set
         if self.max_points is None:
-            return data
+            return occupied
 
         # below limit
-        occ_idx = (data > 0).nonzero(as_tuple=False)  # [n, ndim]
+        occ_idx = occupied.nonzero(as_tuple=False)  # [n, ndim]
         if len(occ_idx) <= self.max_points:
-            return data
+            return occupied
 
         # sampling required
         if data.dtype == torch.bool:
@@ -72,11 +74,8 @@ class PointCloudMetric(ABC):
             weights = torch.sigmoid(data[tuple(occ_idx.T)])
         sampled = torch.multinomial(weights, self.max_points, replacement=False)
         keep = occ_idx[sampled]
-        result = torch.zeros_like(data)
-        if data.dtype == torch.bool:
-            result[tuple(keep.T)] = True
-        else:
-            result[tuple(keep.T)] = data[tuple(keep.T)]
+        result = torch.zeros_like(occupied)
+        result[tuple(keep.T)] = True
 
         return result
 
@@ -148,7 +147,7 @@ class PolarChamfer2D(PointCloudMetric):
         self.az_max = az_max
 
     def as_points(
-        self, data: Shaped[Tensor, "azimuth range"]
+        self, data: Bool[Tensor, "azimuth range"]
     ) -> Float[Tensor, "n 2"]:
         """Convert (azimuth, range) occupancy grid to points."""
         Na, Nr = data.shape
@@ -200,7 +199,7 @@ class PolarChamfer3D(PointCloudMetric):
         self.el_max = el_max
 
     def as_points(
-        self, data: Shaped[Tensor, "elevation azimuth range"]
+        self, data: Bool[Tensor, "elevation azimuth range"]
     ) -> Float[Tensor, "n 3"]:
         """Convert (elevation, azimuth, range) occupancy grid to points."""
         Ne, Na, _Nr = data.shape

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -299,10 +299,8 @@ def test_polar_chamfer_3d_float_logits_below_limit():
     data[1, 2, 5] = 0.5
     data[2, 3, 10] = 1.0
 
-    limited = chamfer._limit(data)
-    points = chamfer.as_points(limited)
+    points = chamfer.as_points(data)
 
-    assert limited.dtype == torch.bool
     assert points.shape == (2, 3)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -292,6 +292,20 @@ def test_polar_chamfer_3d_basic():
     assert torch.all(loss >= 0)
 
 
+def test_polar_chamfer_3d_float_logits_below_limit():
+    """Test PolarChamfer3D ignores negative logits below max_points."""
+    chamfer = PolarChamfer3D(max_points=10000)
+    data = -torch.ones(4, 8, 16)
+    data[1, 2, 5] = 0.5
+    data[2, 3, 10] = 1.0
+
+    limited = chamfer._limit(data)
+    points = chamfer.as_points(limited)
+
+    assert limited.dtype == torch.bool
+    assert points.shape == (2, 3)
+
+
 def test_polar_chamfer_3d_modes():
     """Test PolarChamfer3D with different modes."""
     # Shape: [batch, elevation, azimuth, range]


### PR DESCRIPTION
Fixes point-cloud limiting so float logits are converted to boolean occupancy masks before `as_points`. Logits are still used for weighted sampling, but `_limit` now consistently returns Bool tensors.