### PR TITLE
Allow proceeding if directory doesn't contain checkpoints

### DIFF
--- a/src/nrdk/config/config.py
+++ b/src/nrdk/config/config.py
@@ -152,8 +152,14 @@ class PreventHydraOverwrite(Callback):
 
         output_dir = config.hydra.run.dir
         if os.path.exists(output_dir):
-            if "checkpoints" in os.listdir(output_dir):
+            if os.path.isdir(output_dir):
+                if "checkpoints" in os.listdir(output_dir):
+                    logging.error(
+                        f"Aborting: output directory '{output_dir}' already "
+                        f"exists and contains checkpoints.")
+                    exit(1)
+            else:
                 logging.error(
-                    f"Aborting: output directory '{output_dir}' already "
-                    f"exists and contains checkpoints.")
+                    f"Aborting: output directory path '{output_dir}' already "
+                    f"exists, but is not a directory.")
                 exit(1)

--- a/src/nrdk/config/config.py
+++ b/src/nrdk/config/config.py
@@ -152,6 +152,8 @@ class PreventHydraOverwrite(Callback):
 
         output_dir = config.hydra.run.dir
         if os.path.exists(output_dir):
-            logging.error(
-                f"Aborting: output directory '{output_dir}' already exists!")
-            exit(1)
+            if "checkpoints" in os.listdir(output_dir):
+                logging.error(
+                    f"Aborting: output directory '{output_dir}' already "
+                    f"exists and contains checkpoints.")
+                exit(1)


### PR DESCRIPTION
Don't `PreventHydraOverwrite` if the target directory doesn't contain any `checkpoints/`