### PR TITLE
More and better types

### DIFF
--- a/src/nrdk/types.py
+++ b/src/nrdk/types.py
@@ -18,3 +18,10 @@ class SpectrumData(Protocol, Generic[TArray]):
 
     spectrum: Float[TArray, "batch t doppler x1 x2 rng ch"]
     timestamps: Float[TArray, "batch t"]
+
+
+@runtime_checkable
+class HasTimestamps(Protocol, Generic[TArray]):
+    """Protocol for data with timestamps."""
+
+    timestamps: Float[TArray, "batch t"]

--- a/src/nrdk/types.py
+++ b/src/nrdk/types.py
@@ -1,18 +1,20 @@
 """Protocol types for defining interoperable interfaces."""
 
-from typing import Protocol, runtime_checkable
+from typing import Generic, Protocol, runtime_checkable
 
+from abstract_dataloader.ext.types import TArray
 from jaxtyping import Float
-from torch import Tensor
 
 
 @runtime_checkable
-class SpectrumData(Protocol):
+class SpectrumData(Protocol, Generic[TArray]):
     """Spectrum data with two angular and/or spatial axes.
 
     Attributes:
         spectrum: spectrum tensor; `x1, x2` can be any angular or antenna
             representation, i.e., `tx-rx` or `el-az`.
+        timestamps: timestamps for each spectrum frame.
     """
 
-    spectrum: Float[Tensor, "batch t doppler x1 x2 rng ch"]
+    spectrum: Float[TArray, "batch t doppler x1 x2 rng ch"]
+    timestamps: Float[TArray, "batch t"]


### PR DESCRIPTION
- Make SpectrumData generic, and add `timestamps`
- Add a dedicated HasTimestamps protocol