### PR TITLE
Fix gradient stats computation when gradient accumulation is enabled

### DIFF
--- a/src/nrdk/framework/callbacks.py
+++ b/src/nrdk/framework/callbacks.py
@@ -76,36 +76,30 @@ class GradientStats(Callback):
         self.interval = interval
         self.name = name
 
-        self.__reset_stats()
-
-    def __reset_stats(self) -> None:
-        self.m1 = 0.0
-        self.m2 = 0.0
-        self.min = float('inf')
-        self.max = 0.0
+        # Buffer (instead of accumulating) for numerical stability
+        # The memory overhead should be negligible.
+        self.norms: list[float] = []
 
     def on_before_optimizer_step(self, trainer, pl_module, optimizer) -> None:
-        # Note that gradients should be synchronized across shards already!
-        norm = torch.nn.utils.get_total_norm(
+        # We use the `on_before_optimizer_step` hook instead of a backward hook
+        # so that gradient accumulation gives a single measurement per logical
+        # step.
+        # - Gradients should be synchronized across shards already.
+        # - If AMP is used, the gradients are unscaled at this point, and are
+        #   not yet clipped.
+        self.norms.append(torch.nn.utils.get_total_norm(
             p.grad for p in pl_module.parameters() if p.grad is not None
-        ).item()
+        ).item())
 
-        self.m1 += norm
-        self.m2 += norm**2
-        self.min = min(self.min, norm)
-        self.max = max(self.max, norm)
-
-        if (trainer.global_step + 1) % self.interval == 0:
-            mean = self.m1 / self.interval
-
+        if len(self.norms) >= self.interval:
+            norms = np.array(self.norms)
             stats = {
-                f"{self.name}/mean": mean,
-                f"{self.name}/std": np.sqrt(
-                    (self.m2 / self.interval) - mean**2),
-                f"{self.name}/min": self.min,
-                f"{self.name}/max": self.max,
+                f"{self.name}/mean": float(norms.mean()),
+                f"{self.name}/std": float(norms.std()),
+                f"{self.name}/min": float(norms.min()),
+                f"{self.name}/max": float(norms.max()),
             }
             # Synchronization not necessary!
             pl_module.log_dict(stats, on_step=True, sync_dist=False)
 
-            self.__reset_stats()
+            self.norms.clear()

--- a/src/nrdk/framework/callbacks.py
+++ b/src/nrdk/framework/callbacks.py
@@ -84,7 +84,7 @@ class GradientStats(Callback):
         self.min = float('inf')
         self.max = 0.0
 
-    def on_after_backward(self, trainer, pl_module) -> None:
+    def on_before_optimizer_step(self, trainer, pl_module, optimizer) -> None:
         # Note that gradients should be synchronized across shards already!
         norm = torch.nn.utils.get_total_norm(
             p.grad for p in pl_module.parameters() if p.grad is not None

--- a/tests/framework/test_callbacks.py
+++ b/tests/framework/test_callbacks.py
@@ -25,19 +25,21 @@ class _RecordingGradModule(nn.Module):
         self.log_dict_calls.append((dict(values), kwargs))
 
 
-def _backward(
+def _before_optimizer_step(
     callback: GradientStats, step: int, pl_module: _RecordingGradModule
 ) -> None:
-    """Call `on_after_backward` with a lightweight `trainer` stand-in.
+    """Call `on_before_optimizer_step` with a lightweight `trainer` stand-in.
 
     `trainer`/`pl_module` are cast to `Trainer`/`LightningModule` purely to
-    satisfy static typing -- `on_after_backward`'s real signature expects
-    those types, but only reads a couple of duck-typed attributes from each,
-    so a lightweight stand-in is enough at runtime.
+    satisfy static typing -- `on_before_optimizer_step`'s real signature
+    expects those types, but only reads a couple of duck-typed attributes
+    from each, so a lightweight stand-in is enough at runtime. `optimizer`
+    is unused by the callback, so a placeholder is sufficient.
     """
     trainer = SimpleNamespace(global_step=step)
-    callback.on_after_backward(
-        cast(Trainer, trainer), cast(LightningModule, pl_module))
+    callback.on_before_optimizer_step(
+        cast(Trainer, trainer), cast(LightningModule, pl_module),
+        cast(torch.optim.Optimizer, object()))
 
 
 # GradientStats
@@ -50,7 +52,7 @@ def test_gradient_stats_does_not_log_before_interval_reached():
     for step in range(3):
         pl_module.weights[0].grad = torch.tensor(
             [float(step + 1), 0.0, 0.0, 0.0])
-        _backward(callback, step, pl_module)
+        _before_optimizer_step(callback, step, pl_module)
 
     assert pl_module.log_dict_calls == []
 
@@ -65,7 +67,7 @@ def test_gradient_stats_logs_analytical_mean_std_min_max():
     for step, norm in enumerate(norms):
         # A single nonzero component gives an exact L2 norm of `norm`.
         pl_module.weights[0].grad = torch.tensor([norm, 0.0, 0.0, 0.0])
-        _backward(callback, step, pl_module)
+        _before_optimizer_step(callback, step, pl_module)
 
     assert len(pl_module.log_dict_calls) == 1
     logged, kwargs = pl_module.log_dict_calls[0]
@@ -88,7 +90,7 @@ def test_gradient_stats_resets_accumulators_after_logging():
 
     for step, norm in enumerate([1.0, 2.0]):
         pl_module.weights[0].grad = torch.tensor([norm, 0.0, 0.0, 0.0])
-        _backward(callback, step, pl_module)
+        _before_optimizer_step(callback, step, pl_module)
 
     assert len(pl_module.log_dict_calls) == 1
     assert callback.m1 == 0.0
@@ -105,7 +107,7 @@ def test_gradient_stats_ignores_parameters_without_grad():
     pl_module.weights[0].grad = torch.tensor([3.0, 4.0, 0.0, 0.0])  # norm 5
     pl_module.weights[1].grad = None
 
-    _backward(callback, 0, pl_module)
+    _before_optimizer_step(callback, 0, pl_module)
 
     logged, _ = pl_module.log_dict_calls[0]
     assert logged["grad_norm/mean"] == pytest.approx(5.0)
@@ -121,7 +123,7 @@ def test_gradient_stats_combines_norms_across_multiple_parameters():
     pl_module.weights[0].grad = torch.tensor([3.0, 0.0, 0.0, 0.0])
     pl_module.weights[1].grad = torch.tensor([4.0, 0.0, 0.0, 0.0])
 
-    _backward(callback, 0, pl_module)
+    _before_optimizer_step(callback, 0, pl_module)
 
     logged, _ = pl_module.log_dict_calls[0]
     # Concatenated vector norm: sqrt(3^2 + 4^2) == 5.

--- a/tests/framework/test_callbacks.py
+++ b/tests/framework/test_callbacks.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from lightning import LightningModule, Trainer
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
 
 from nrdk.framework.callbacks import GradientStats
 
@@ -22,6 +23,30 @@ class _RecordingGradModule(nn.Module):
         self.log_dict_calls: list[tuple[dict, dict]] = []
 
     def log_dict(self, values: dict, **kwargs) -> None:
+        self.log_dict_calls.append((dict(values), kwargs))
+
+
+class _AccumulatingModule(LightningModule):
+    """Trainable `LightningModule` with a recording `log_dict`.
+
+    Used to exercise `GradientStats` through a real `Trainer` run; the
+    recording `log_dict` intercepts the callback's logging without needing
+    a logger to be attached.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = nn.Linear(4, 1)
+        self.log_dict_calls: list[tuple[dict, dict]] = []
+
+    def training_step(self, batch, batch_idx) -> torch.Tensor:
+        (inputs,) = batch
+        return self.layer(inputs).square().mean()
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        return torch.optim.SGD(self.parameters(), lr=0.1)
+
+    def log_dict(self, values: dict, **kwargs) -> None:  # type: ignore[override]
         self.log_dict_calls.append((dict(values), kwargs))
 
 
@@ -84,7 +109,7 @@ def test_gradient_stats_logs_analytical_mean_std_min_max():
 
 
 def test_gradient_stats_resets_accumulators_after_logging():
-    """Internal accumulators reset to their initial values after logging."""
+    """The buffered window is cleared after logging."""
     callback = GradientStats(interval=2)
     pl_module = _RecordingGradModule()
 
@@ -93,10 +118,7 @@ def test_gradient_stats_resets_accumulators_after_logging():
         _before_optimizer_step(callback, step, pl_module)
 
     assert len(pl_module.log_dict_calls) == 1
-    assert callback.m1 == 0.0
-    assert callback.m2 == 0.0
-    assert callback.min == float("inf")
-    assert callback.max == 0.0
+    assert callback.norms == []
 
 
 def test_gradient_stats_ignores_parameters_without_grad():
@@ -128,3 +150,34 @@ def test_gradient_stats_combines_norms_across_multiple_parameters():
     logged, _ = pl_module.log_dict_calls[0]
     # Concatenated vector norm: sqrt(3^2 + 4^2) == 5.
     assert logged["grad_norm/mean"] == pytest.approx(5.0)
+
+
+def test_gradient_stats_logs_once_per_optimizer_step_under_accumulation():
+    """Gradient accumulation yields one measurement per optimizer step."""
+    torch.manual_seed(0)
+    pl_module = _AccumulatingModule()
+    callback = GradientStats(interval=2, name="grad_norm")
+    trainer = Trainer(
+        accumulate_grad_batches=4, max_epochs=1, callbacks=[callback],
+        accelerator="cpu", devices=1, logger=False,
+        enable_checkpointing=False, enable_progress_bar=False,
+        enable_model_summary=False)
+
+    dataset = TensorDataset(torch.randn(8, 4))
+    trainer.fit(pl_module, DataLoader(dataset, batch_size=1))
+
+    # 8 batches accumulated 4 at a time is 2 optimizer steps, so `interval=2`
+    # closes exactly one window. Measuring on a backward hook would instead
+    # see 8 measurements, and close four.
+    assert trainer.global_step == 2
+    assert len(pl_module.log_dict_calls) == 1
+
+    logged, kwargs = pl_module.log_dict_calls[0]
+    assert kwargs == {"on_step": True, "sync_dist": False}
+    # The two steps have distinct norms, and for a two-sample window the mean
+    # and std are exactly the midpoint and half-spread of the extremes.
+    assert logged["grad_norm/min"] < logged["grad_norm/max"]
+    assert logged["grad_norm/mean"] == pytest.approx(
+        (logged["grad_norm/min"] + logged["grad_norm/max"]) / 2)
+    assert logged["grad_norm/std"] == pytest.approx(
+        (logged["grad_norm/max"] - logged["grad_norm/min"]) / 2)


### PR DESCRIPTION
Fix for #38 by using `on_before_optimizer_step` instead of `on_backwards`.

We also address some subtle bugs:
- Switch Welford moment accumulation (`E[X^2] - E[X]^2`) to explicit (`E[(X - E[X])^2]`) for better numerical stability
- This also fixes gradient stats calculation if training resumes in the middle of a logging interval.